### PR TITLE
 Remove stray semicolon

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,6 @@ fn main() {
 
     //or
 
-    let rust_code = r#"println!("Hello World! from Rust");"#;
+    let rust_code = r#"println!("Hello World! from Rust")"#;
     gen_file_str("hello.rs", &rust_code);
 }


### PR DESCRIPTION
This semicolon is currently silently ignored, but we may be changing that in the future.

cc rust-lang/rust#64284